### PR TITLE
[#174417824] Adding git-secrets on pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # GIT HOOKS
 
-A collection of useful git hooks to automate part of our workflow
+A collection of opinionated git hooks to automate part of our workflow
+
+## Features
+* Prevent from committing secrets
+* Update dependencies when switching/merging branches
+* Prevent from pushing untested code
+
+## Requirements
+* `git-secrets` - see [here](https://github.com/awslabs/git-secrets) for more info.
 
 ## Installation
 

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -10,4 +10,4 @@ check_run() {
 }
 
 # run yarn install when dependencies have changed
-check_run yarn.lock "yarn cache list && yarn install"
+check_run yarn.lock "yarn cache clean && yarn install"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# Enure everything is fine before committing stuff
+#
+
+git secrets --pre_commit_hook -- "$@"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,7 +1,23 @@
 #!/bin/bash
 
 #
-# Enure everything is fine before committing stuff
+# Ensure everything is fine before committing stuff
 #
+
+# Test if you can actually execute the provider
+PROVIDER_COMMAND=$(git config --get secrets.providers)
+if [ ! -z "$PROVIDER_COMMAND" ]; then
+    # no need to print the output
+    $($PROVIDER_COMMAND > /dev/null 2>&1)
+    RETURN_CODE=$?
+    if [ $RETURN_CODE -ne 0 ]; then
+        echo "Provider command:"
+        echo "$PROVIDER_COMMAND"
+        echo "The above command failed execution. Nothing has been commited."
+        echo "Please check your .git/config file, secrets.providers section."
+        # whatever value != 0
+        exit $RETURN_CODE
+    fi
+fi
 
 git secrets --pre_commit_hook -- "$@"

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ declare -a hooks=(
     "post-checkout"
     "post-merge"
     "pre-push"
+    "pre-commit"
 )
 
 # install each hook
@@ -36,3 +37,24 @@ do
 
     chmod +x "$dest"
 done
+
+# Install git-secrets command
+function command_exists {
+  #this should be a very portable way of checking if something is on the path
+  #usage: "if command_exists foo; then echo it exists; fi"
+  type "$1" &> /dev/null
+}
+
+if [ ! -f /usr/local/bin/git-secrets ]; then 
+    echo "You don't have git secrets installed. It will be used by some hooks."
+    read -p "Would you like to install git secrets (y/n)? " -n 1 -r
+    echo   
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installing git-secrets"
+        download_dir="/tmp/git-secrets-$(date +%s)"
+        git clone --depth 1 https://github.com/awslabs/git-secrets.git $download_dir
+        cd $download_dir || exit
+        make install
+        echo "git-secrets installed. Please see https://github.com/awslabs/git-secrets for command usage."
+    fi
+fi

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,14 @@
 # cd myproject/
 # ../git-hooks/install.sh
 
+# Github references
+repo=pagopa/git-hooks
+branch=master
+
+# to use local files instead of github's
+is_local=$1
+
+
 # check if is a git repo
 if [ ! -d ".git" ]; then
   echo "Please run this script inside your target git repository"
@@ -13,10 +21,10 @@ fi
 # check if git-secrets is installed
 if [ ! -x $(command -v git-secrets > /dev/null 2>&1) ]; then
     echo "The git-secrets binary is not available. Install from source or package or check your PATH."
+    echo "Visit https://github.com/awslabs/git-secrets for instructions."
     exit 1
 fi
 
-# TODO we could avoid the array declaration and traverse the dirs
 # hooks to be installed
 declare -a hooks=(
     "post-checkout"
@@ -30,17 +38,32 @@ declare -a providers=(
     "commons"
 )
 
-# get script directory
-script_directory="$(dirname $0)"
+# copy a file from current file system or from github, depending from the value of $is_local
+function copyFile {
+    source=$1
+    dest=$2
+    if [ -z "$is_local" ]; then
+        url="https://raw.githubusercontent.com/$repo/$branch/$source"
+        echo "Download from $url"
+        curl "$url" -o "$dest"
+    else 
+        # get script directory
+        script_directory="$(dirname $0)"
+        file="$script_directory/$source"
+        echo "Copying $file"
+        cp "$file" "$dest"
+    fi
+}
+
 
 # install each hook
 mkdir -p ".git/hooks"
 for hook in "${hooks[@]}"
 do
+    source="hooks/$hook"
     dest=".git/hooks/$hook"
-    file="$script_directory/hooks/$hook"
-    echo "Copying hook file: $file"
-    cp "$file" "$dest"
+    copyFile "$source" "$dest"
+    # make the hook executable
     chmod +x "$dest"
 done
 
@@ -49,14 +72,13 @@ done
 mkdir -p ".git/git-secrets-providers"
 for provider in "${providers[@]}"
 do
+    source="providers/$provider"
     dest=".git/git-secrets-providers/$provider"
-    file="$script_directory/providers/$provider"
-    echo "Copying provider file: $file"
-    cp "$file" "$dest"
+    copyFile "$source" "$dest"
     # add patterns
-    git secrets --add-provider -- grep '^[^#[:space:]]' $dest
+    git secrets --add-provider -- grep '^[^#[:space:]]' "$dest"
     echo "Added the following patterns to block local commits:"
-    grep '^[^#[:space:]]' $dest # maybe avoid if too verbose in future
+    grep '^[^#[:space:]]' "$dest" # maybe avoid if too verbose in future
 done
 
 printf "\nAll done!\n"

--- a/providers/commons
+++ b/providers/commons
@@ -1,0 +1,11 @@
+# Author: security@pagopa.it
+# Description: list of regex for "incidents" that happened at least once
+# Usage: meant to be used as a provider file for git-secrets (grep "^[^#[:space:]]" file)
+
+
+# Azure Storage Account Access Key (so far they have this format)
+# alternatively we can grep for endpoint suffixes like core.windows.net
+[A-Za-z0-9+\/]{86}==
+
+# Slack tokens, more generic than bot tokens (xoxb-***)
+xox[a|b|p|o]-[a-zA-Z0-9-]*


### PR DESCRIPTION
Add a `pre-commit` hook that execute `git-secrets` on changes that are about to be committed, to prevent secrets to be leaked.

Plus: add a facility on the installation script that optionally installs `git-secrets` if it's not found on the machine.