### PR TITLE
Fix for letting 'git rebase' works

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -18,3 +18,6 @@ check_run() {
 
 # run yarn install when dependencies have changed
 check_run yarn.lock "yarn cache clean && yarn install"
+
+
+exit 0;


### PR DESCRIPTION
Added exit command. This is needed because of 'git rebase' command fail.