### PR TITLE
[#IP-80] git-secrets must not block yarn.lock commit due to integrity sha512

### DIFF
--- a/alloweds/commons
+++ b/alloweds/commons
@@ -1,0 +1,7 @@
+# Author: security@pagopa.it
+# Description: list of regex for simil-secrets allowed to be committed
+# Usage: meant to be used as a allowed file for git-secrets (grep "^[^#[:space:]]" file)
+
+
+# package integrity hash string (used by yarn.lock)
+integrity sha512-[A-Za-z0-9+\/]{86}==

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,11 @@ declare -a providers=(
     "commons"
 )
 
+# allowed to be installed
+declare -a alloweds=(
+    "commons"
+)
+
 # copy a file from current file system or from github, depending from the value of $is_local
 function copyFile {
     source=$1
@@ -80,6 +85,19 @@ do
     git secrets --add-provider -- grep '^[^#[:space:]]' "$dest"
     echo "Added the following patterns to block local commits:"
     grep '^[^#[:space:]]' "$dest" # maybe avoid if too verbose in future
+done
+
+# install each allowed and setup the git-secrets engine
+# the configuration is saved in .git/config secrets.allowed section
+mkdir -p ".git/git-secrets-alloweds"
+for allowed in "${alloweds[@]}"
+do
+    source="alloweds/$allowed"
+    dest=".git/git-secrets-alloweds/$allowed"
+    copyFile "$source" "$dest"
+    grep '^[^#[:space:]]' "$dest" | xargs -I{} git secrets --add -a "{}"
+    echo "Added the following patterns to ALLOW local commits:"
+    grep '^[^#[:space:]]' "$dest"
 done
 
 printf "\nAll done!\n"


### PR DESCRIPTION
The current Azure key regex can match the integrity has value used by yarn.

A git-secrets allowed configuration section has been add in the install.sh in order to configure an exception. Following the current project structure, a new folder "alloweds" has been created containing a "commons" file with the allowed regex to configure. The install.sh will dowload/read this file and call the git-secrets -allow  command for each valid line.

A regex to exclude the "integrity sha512<simil-azure-key" has been added to alloweds/commons configuration.