### PR TITLE
[#IP-151] git-hooks commit match do not works for Jira issue ID encoding

### DIFF
--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -26,7 +26,7 @@ MAX_MSG_LENGHT=72
 IS_A_NUMBER_REGEX='^[0-9]+$'
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-ID=$(get_id_by_brench "$BRANCH_NAME")
+ID=$(get_id_by_branch "$BRANCH_NAME")
 
 if [[ ! -z "$ID" ]] ; then
    COMMIT_MSG=$(cat ${1})   

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -3,7 +3,7 @@
 #
 # Get the story/issue ID from the input branch name
 #
-get_id_by_brench () {
+get_id_by_branch () {
    SPLITTED_BRANCH=($(echo "$1" | tr '-' '\n'))
    STORY_ID="${SPLITTED_BRANCH[0]}"
    ISSUE_ID="${SPLITTED_BRANCH[1]}"

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,21 +1,38 @@
 #!/bin/sh
+
 #
-# Automatically adds story id to every commit message.
+# Get the story/issue ID from the input branch name
+#
+get_id_by_brench () {
+   SPLITTED_BRANCH=($(echo "$1" | tr '-' '\n'))
+   STORY_ID="${SPLITTED_BRANCH[0]}"
+   ISSUE_ID="${SPLITTED_BRANCH[1]}"
+
+   # If the branch name start with a number, is a legacy pivotal story
+   if [[ $STORY_ID =~ $IS_A_NUMBER_REGEX ]] ; then
+      echo "[#$STORY_ID]";
+   # If the branch name start with <anything>-<a number>, is a Jira issue
+   elif [[ $ISSUE_ID =~ $IS_A_NUMBER_REGEX ]] ; then
+      echo "[#$STORY_ID-$ISSUE_ID]";
+   else
+      echo "";
+   fi
+}
+
+#
+# Automatically adds story/issue id to every commit message.
 #
 MAX_MSG_LENGHT=72
 IS_A_NUMBER_REGEX='^[0-9]+$'
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-SPLITTED_BRANCH=($(echo "$BRANCH_NAME" | tr '-' '\n'))
-STORY_ID="${SPLITTED_BRANCH[0]}"
+ID=$(get_id_by_brench "$BRANCH_NAME")
 
-COMMIT_MSG=$(cat ${1})
-
-TOTAL_MSG_LENGHT=$((${#COMMIT_MSG}+${#STORY_ID}+3))
-
-if [[ $STORY_ID =~ $IS_A_NUMBER_REGEX ]] ; then
+if [[ ! -z "$ID" ]] ; then
+   COMMIT_MSG=$(cat ${1})   
+   TOTAL_MSG_LENGHT=$((${#COMMIT_MSG}+${#ID}+3))
    if (( $TOTAL_MSG_LENGHT < $MAX_MSG_LENGHT)); then
-      sed -i '.bak' "1s/^/[#$STORY_ID] /" $1
+      sed -i '.bak' "1s/^/$ID /" $1
    else
       echo "Commit message longer than ${MAX_MSG_LENGHT} characters"
       exit 1


### PR DESCRIPTION
The prapare-commit-msg hook identify only the Pivotal Story ID from the branch name. 
The git hook has been changed to match both the paths:

- _**[pivoltal-issue-id]**_-reamaning-branch-name
- **_[jira-project-id]-[jira-issue-number]_**-reamaning-branch-name